### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,10 @@
 #-include ../config.mk
 
 EX = cHNLdecay
-CC = gcc
-CXX = g++
-RM = rm -f
-CPPFLAGS = -g $(shell root-config --cflags) -I/usr/include
-LDFLAGS = -g $(shell root-config --ldflags)
-LDLIBS = $(shell root-config --libs) -lmpfr -lgmp -L/usr/lib -L/usr/lib64
-LDLIBS_DBG = $(shell root-config --libs) -lmpfr -lgmp -L/usr/lib -L/usr/lib64 -lprofiler -ltcmalloc
+CPPFLAGS += -g $(shell root-config --cflags)
+LDFLAGS += -g $(shell root-config --ldflags)
+LDLIBS += $(shell root-config --libs) -lmpfr -lgmp
+LDLIBS_DBG += $(shell root-config --libs) -lmpfr -lgmp -lprofiler -ltcmalloc
 
 SRCS = $(wildcard *.cxx)
 #SRCS = auxfunctions.cxx HNL.cxx Logger.cxx partialWidths.cxx plots.cxx prodFromBmesons.cxx


### PR DESCRIPTION
These values are defined by default and overriding them breaks non-system installs, see https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html

With this change it the error messages make clear that the actual issue is that gmp and mpfr are not install in the default lb-conda environment:

```
In file included from HNL.h:22:0,
                 from cHNLdecay.cxx:28:
Config.h:26:10: fatal error: gmp.h: No such file or directory
 #include <gmp.h>
          ^~~~~~~
compilation terminated.
make: *** [Makefile:31: cHNLdecay.o] Error 1
```

The missing packages will be added in a couple of hours by https://gitlab.cern.ch/lhcb-core/conda-environments/-/merge_requests/15. If you're impatient, private message me on mattermost and I'll send you a hacky workaround. 